### PR TITLE
Populate GelfJson with MappedDiagnosticsLogicalContext data

### DIFF
--- a/NLog.Web.AspNetCore.Targets.Gelf.Tests/GelfConverterTests.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf.Tests/GelfConverterTests.cs
@@ -1,0 +1,38 @@
+using Xunit;
+
+namespace NLog.Web.AspNetCore.Targets.Gelf.Tests
+{
+    public class GelfConverterTests
+    {
+        [Fact]
+        public void ShouldGetGelfJsonAddMappedDiagnosticsLogicalContextData()
+        {
+            MappedDiagnosticsLogicalContext.Set("test", "value");
+
+            var logEvent = LogEventInfo.Create(LogLevel.Info, "loggerName", null, "message");
+
+            var converter = new GelfConverter();
+
+            // Act
+            var gelfJson = converter.GetGelfJson(logEvent, "facility");
+
+            Assert.Equal("value", gelfJson.Value<string>("_test"));
+        }
+
+        [Fact]
+        public void ShouldGetGelfJsonDiscardMappedDiagnosticsLogicalContextDataIfPresentInLogEventInfo()
+        {
+            MappedDiagnosticsLogicalContext.Set("test", "value");
+            
+            var logEvent = LogEventInfo.Create(LogLevel.Info, "loggerName", null, "message");
+            logEvent.Properties.Add("test", "anotherValue");
+
+            var converter = new GelfConverter();
+
+            // Act
+            var gelfJson = converter.GetGelfJson(logEvent, "facility");
+
+            Assert.Equal("anotherValue", gelfJson.Value<string>("_test"));
+        }
+    }
+}

--- a/NLog.Web.AspNetCore.Targets.Gelf.Tests/NLog.Web.AspNetCore.Targets.Gelf.Tests.csproj
+++ b/NLog.Web.AspNetCore.Targets.Gelf.Tests/NLog.Web.AspNetCore.Targets.Gelf.Tests.csproj
@@ -15,4 +15,7 @@
     <EmbeddedResource Include="..\NLog.Web.AspNetCore.Targets.Gelf.Tests\Resources\LongMessage.txt">
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfConverter.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Text;
 using Newtonsoft.Json.Linq;
@@ -65,6 +66,16 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
 
             //Add any other interesting data to LogEventInfo properties
             logEventInfo.Properties.Add("LoggerName", logEventInfo.LoggerName);
+
+            // adding MappedDiagnosticsLogicalContext data
+            MappedDiagnosticsLogicalContext.GetNames()
+                .Select(n => (Name: n, Value: MappedDiagnosticsLogicalContext.GetObject(n)))
+                .ToList()
+                .ForEach(t =>
+                {
+                    if (!logEventInfo.Properties.ContainsKey(t.Name))
+                        logEventInfo.Properties.Add(t.Name, t.Value);
+                });
 
             //We will persist them "Additional Fields" according to Gelf spec
             foreach (var property in logEventInfo.Properties)


### PR DESCRIPTION
The purpose of this would be to have the data in MDLC in gelf json. Why and when is it useful?
For instance the Microsoft Extension Logging scope data is pushed by NLog into MDLC. (see  https://github.com/NLog/NLog.Extensions.Logging/wiki/NLog-properties-with-Microsoft-Extension-Logging)
With this change we could be able to log this data as well.