### PR TITLE
Update timestamp format to GELF 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ msbuild.wrn
 
 # Visual Studio 2015
 .vs/
+/NLog.Web.AspNetCore.Targets.Gelf.ConsoleRunner/Logs/internal-nlog.txt

--- a/NLog.Web.AspNetCore.Targets.Gelf.ConsoleRunner/NLog.Web.AspNetCore.Targets.Gelf.ConsoleRunner.csproj
+++ b/NLog.Web.AspNetCore.Targets.Gelf.ConsoleRunner/NLog.Web.AspNetCore.Targets.Gelf.ConsoleRunner.csproj
@@ -9,4 +9,9 @@
   <ItemGroup>
     <ProjectReference Include="..\NLog.Web.AspNetCore.Targets.Gelf\NLog.Web.AspNetCore.Targets.Gelf.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="nlog.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/NLog.Web.AspNetCore.Targets.Gelf.ConsoleRunner/nlog.config
+++ b/NLog.Web.AspNetCore.Targets.Gelf.ConsoleRunner/nlog.config
@@ -11,7 +11,7 @@
   </extensions>
   <targets>
     <target xsi:type="File" name="debugFile" filename="C:\@Logs\${shortdate}-${level}-${applicationName}.txt" layout="${longdate}|${level:upperCase=true}|${logger}|${aspnet-Request-Method}|url: ${aspnet-Request-Url}${aspnet-Request-QueryString}|${message}" concurrentWrites="false" />
-    <target xsi:type="Gelf" name="graylog" endpoint="udp://192.168.99.100:12201" facility="console-runner" SendLastFormatParameter="true" />
+    <target xsi:type="Gelf" name="graylog" endpoint="udp://192.168.1.153:12201" facility="console-runner" SendLastFormatParameter="true" />
   </targets>
   <rules>
     <logger name="*" minlevel="Debug" writeTo="debugFile, graylog" />

--- a/NLog.Web.AspNetCore.Targets.Gelf.ConsoleRunner/nlog.config
+++ b/NLog.Web.AspNetCore.Targets.Gelf.ConsoleRunner/nlog.config
@@ -3,14 +3,14 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       autoReload="true"
       throwExceptions="false"
-      internalLogLevel="Off"
-      internalLogFile="c:\temp\internal-nlog.txt">
+      internalLogLevel="Trace"
+      internalLogFile="Logs\internal-nlog.txt">
   <extensions>
     <add assembly="NLog.Web.AspNetCore"/>
     <add assembly="NLog.Web.AspNetCore.Targets.Gelf"/>
   </extensions>
   <targets>
-    <target xsi:type="File" name="debugFile" filename="C:\@Logs\${shortdate}-${level}-${applicationName}.txt" layout="${longdate}|${level:upperCase=true}|${logger}|${aspnet-Request-Method}|url: ${aspnet-Request-Url}${aspnet-Request-QueryString}|${message}" concurrentWrites="false" />
+    <target xsi:type="File" name="debugFile" filename="Logs\${shortdate}${applicationName}.txt" layout="${longdate}|${level:upperCase=true}|${logger}|${aspnet-Request-Method}|url: ${aspnet-Request-Url}${aspnet-Request-QueryString}|${message}" concurrentWrites="false" />
     <target xsi:type="Gelf" name="graylog" endpoint="udp://192.168.1.153:12201" facility="console-runner" SendLastFormatParameter="true" />
   </targets>
   <rules>

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfConverter.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfConverter.cs
@@ -131,19 +131,15 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
         /// <returns></returns>
         private static int GetSeverityLevel(LogLevel level)
         {
+            if (level == LogLevel.Trace)
+            {
+                return 7;
+            }
             if (level == LogLevel.Debug)
             {
                 return 7;
             }
-            if (level == LogLevel.Fatal)
-            {
-                return 2;
-            }
             if (level == LogLevel.Info)
-            {
-                return 6;
-            }
-            if (level == LogLevel.Trace)
             {
                 return 6;
             }
@@ -151,8 +147,16 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
             {
                 return 4;
             }
+            if (level == LogLevel.Error)
+            {
+                return 3;
+            }
+            if (level == LogLevel.Fatal)
+            {
+                return 2;
+            }
 
-            return 3; //LogLevel.Error
+            return 7; //LogLevel.Off ?
         }
 
         /// <summary>

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfConverter.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfConverter.cs
@@ -48,7 +48,7 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
                                       Host = Dns.GetHostName(),
                                       ShortMessage = shortMessage,
                                       FullMessage = logEventMessage,
-                                      Timestamp = logEventInfo.TimeStamp,
+                                      Timestamp = new DateTimeOffset(logEventInfo.TimeStamp).ToUnixTimeMilliseconds() /1000.0,
                                       Level = GetSeverityLevel(logEventInfo.Level),
                                       //Spec says: facility must be set by the client to "GELF" if empty
                                       Facility = (string.IsNullOrEmpty(facility) ? "GELF" : facility),

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfConverter.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfConverter.cs
@@ -30,6 +30,7 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
 
                 logEventInfo.Properties.Add("ExceptionSource", logEventInfo.Exception.Source);
                 logEventInfo.Properties.Add("ExceptionMessage", exceptionDetail);
+                logEventInfo.Properties.Add("ExceptionType", logEventInfo.Exception?.GetType().FullName);
                 logEventInfo.Properties.Add("StackTrace", stackDetail);
             }
 
@@ -175,17 +176,28 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
             int counter = 0;
             do
             {
-                exceptionSb.Append(nestedException.Message + " - ");
+                exceptionSb.Append(nestedException.GetType().FullName)
+                    .Append(" => ")
+                    .Append(nestedException.Message);
+
+                if(nestedException.InnerException != null)
+                    exceptionSb.Append(" - ");
+
                 if (nestedException.StackTrace != null)
-                    stackSb.Append(nestedException.StackTrace + "--- Inner exception stack trace ---");
+                {
+                    stackSb.Append(nestedException.StackTrace);
+                    if (nestedException.InnerException != null)
+                        stackSb.Append("--- Inner exception stack trace ---");
+                }
+
                 nestedException = nestedException.InnerException;
                 counter++;
             }
             while (nestedException != null && counter < 11);
 
-            exceptionDetail = exceptionSb.ToString().Substring(0, exceptionSb.Length - 3);
+            exceptionDetail = exceptionSb.ToString();
             if (stackSb.Length > 0)
-                stackDetail = stackSb.ToString().Substring(0, stackSb.Length - 35);
+                stackDetail = stackSb.ToString();
         }
     }
 }

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfMessage.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfMessage.cs
@@ -27,7 +27,7 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
         public string ShortMessage { get; set; }
 
         [JsonProperty("timestamp")]
-        public DateTime Timestamp { get; set; }
+        public double Timestamp { get; set; }
 
         [JsonProperty("version")]
         public string Version { get; set; }


### PR DESCRIPTION
If you log to Graylog 2.4 you get lots Graylog log errors : ... has invalid "timestamp" ...
Issue is the format changed in GELF 1.1 from date time string to a double - seconds since UNIX epoch.