### PR TITLE
Configurable format of GELF mesasges.

### DIFF
--- a/NLog.Web.AspNetCore.Targets.Gelf.Tests/UdpTransportTest.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf.Tests/UdpTransportTest.cs
@@ -19,7 +19,7 @@ namespace NLog.Web.AspNetCore.Targets.Gelf.Tests
                 var transport = new UdpTransport(transportClient.Object);
                 var converter = new Mock<IConverter>();
                 var dnslookup = new Mock<DnsBase>();
-                converter.Setup(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>())).Returns(new JObject());
+                converter.Setup(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new JObject());
 
                 var target = new GelfTarget(new []{transport}, converter.Object, dnslookup.Object) {
                     Endpoint = "udp://192.168.99.100:12201"
@@ -30,7 +30,7 @@ namespace NLog.Web.AspNetCore.Targets.Gelf.Tests
                 target.WriteLogEventInfo(logEventInfo);
 
                 transportClient.Verify(t => t.Send(It.IsAny<byte[]>(), It.IsAny<Int32>(), It.IsAny<IPEndPoint>()), Times.Once());
-                converter.Verify(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>()), Times.Once());
+                converter.Verify(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once());
             }
 
             [Fact]
@@ -42,7 +42,7 @@ namespace NLog.Web.AspNetCore.Targets.Gelf.Tests
                 jsonObject.Add("full_message", JToken.FromObject(message));
 
                 var converter = new Mock<IConverter>();
-                converter.Setup(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>())).Returns(jsonObject).Verifiable();
+                converter.Setup(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>(), It.IsAny<string>())).Returns(jsonObject).Verifiable();
                 var transportClient = new Mock<ITransportClient>();
                 transportClient.Setup(t => t.Send(It.IsAny<byte[]>(), It.IsAny<Int32>(), It.IsAny<IPEndPoint>())).Verifiable();
                
@@ -54,7 +54,7 @@ namespace NLog.Web.AspNetCore.Targets.Gelf.Tests
                 };
                 target.WriteLogEventInfo(new LogEventInfo());
 
-                converter.Verify(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>()), Times.Once());
+                converter.Verify(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once());
             }
         }
     }

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfMessageV1_1.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfMessageV1_1.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace NLog.Web.AspNetCore.Targets.Gelf
+{
+    public class GelfMessageV1_1
+    {
+        [JsonProperty("full_message")]
+        public string FullMessage { get; set; }
+
+        [JsonProperty("host")]
+        public string Host { get; set; }
+
+        [JsonProperty("level")]
+        public int Level { get; set; }
+
+        [JsonProperty("short_message")]
+        public string ShortMessage { get; set; }
+
+        [JsonProperty("timestamp")]
+        public double  Timestamp { get; set; }
+
+        [JsonProperty("version")]
+        public string Version { get; set; }
+    }
+}

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfTarget.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfTarget.cs
@@ -37,6 +37,8 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
 
         public bool SendLastFormatParameter { get; set; }
 
+        public string GelfVersion { get; set; } = "1.0";
+
         public IConverter Converter { get; private set; }
         public IEnumerable<ITransport> Transports { get; private set; }
         public DnsBase Dns { get; private set; }
@@ -90,7 +92,7 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
                 logEvent.Properties.Add(ConverterConstants.PromoteObjectPropertiesMarker, logEvent.Parameters.Last());
             }
 
-            var jsonObject = Converter.GetGelfJson(logEvent, Facility);
+            var jsonObject = Converter.GetGelfJson(logEvent, Facility, GelfVersion);
             if (jsonObject == null) return;
             _lazyITransport.Value
                 .Send(_lazyIpEndoint.Value, jsonObject.ToString(Formatting.None, null));

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/IConverter.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/IConverter.cs
@@ -4,6 +4,6 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
 {
     public interface IConverter
     {
-        JObject GetGelfJson(LogEventInfo logEventInfo, string facility);
+        JObject GetGelfJson(LogEventInfo logEventInfo, string facility, string gelfVersion = "1.0");
     }
 }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here is a sample nlog.config configuration file for graylog:
   </extensions>
   <targets>
     <target xsi:type="File" name="debugFile" filename="C:\@Logs\${shortdate}-${level}-${applicationName}.txt" layout="${longdate}|${level:upperCase=true}|${logger}|${aspnet-Request-Method}|url: ${aspnet-Request-Url}${aspnet-Request-QueryString}|${message}" concurrentWrites="false" />
-    <target xsi:type="Gelf" name="graylog" endpoint="udp://192.168.99.100:12201" facility="console-runner" SendLastFormatParameter="true">
+    <target xsi:type="Gelf" name="graylog" endpoint="udp://192.168.99.100:12201" facility="console-runner" SendLastFormatParameter="true" gelfVersion="1.0">
 	
 	<!-- Optional parameters -->
 	<parameter name="param1" layout="${longdate}"/>
@@ -53,6 +53,7 @@ Options are the following:
 * __endpoint:__ the uri pointing to the graylog2 input in the format udp://{IP or host name}:{port} *__note:__ support is currently only for udp transport protocol*
 * __facility:__ The graylog2 facility to send log messages
 * __sendLastFormatParameter:__ default false. If true last parameter of message format will be sent to graylog as separate field per property
+* __gelfVersion:__ default "1.0". Set this to "1.1" in order to use actual GELF message format
 
 ###Code
 ```c#


### PR DESCRIPTION
Current versions of GrayLog uses GELF 1.1 format (http://docs.graylog.org/en/3.0/pages/gelf.html#gelf-payload-specification), but this target sends only 1.0 format messages.

GELF format 1.1 differs from 1.0: "facility", "line" and "file" fields now deprecated and should be send as additional fields instead.
Also "timestamp" field format changed from string representation to unix-time timestamp, and this leads to massive warnings like "GELF message ... has invalid "timestamp": yyyy-mm-dd:hh:mm:ss (type: STRING)' in GrayLog own log file.

This proposed commit enables sending of GELF v.1.1. messages by setting gelfVersion="1.1" parameter of target in NLog.config.

If such a parameter is not specified or differs from "1.1" value - legacy 1.0 format will be used.
