### PR TITLE
TCP transport with SSL support

### DIFF
--- a/NLog.Web.AspNetCore.Targets.Gelf.ConsoleRunner/nlog.config
+++ b/NLog.Web.AspNetCore.Targets.Gelf.ConsoleRunner/nlog.config
@@ -12,6 +12,9 @@
   <targets>
     <target xsi:type="File" name="debugFile" filename="C:\@Logs\${shortdate}-${level}-${applicationName}.txt" layout="${longdate}|${level:upperCase=true}|${logger}|${aspnet-Request-Method}|url: ${aspnet-Request-Url}${aspnet-Request-QueryString}|${message}" concurrentWrites="false" />
     <target xsi:type="Gelf" name="graylog" endpoint="udp://192.168.99.100:12201" facility="console-runner" sendLastFormatParameter="true" gelfVersion="1.1" />
+    <target xsi:type="Gelf" name="graylog" endpoint="tcp://192.168.99.100:12201" ignoreTlsErrors="false" useTls="true" facility="console-runner" sendLastFormatParameter="true" gelfVersion="1.1" />
+    <target xsi:type="Gelf" name="graylog" endpoint="tcp://192.168.99.100:12201" ignoreTlsErrors="false" useTls="true" facility="console-runner" sendLastFormatParameter="true" gelfVersion="1.1" clientCertificate="file:cert.pfx" />
+    <target xsi:type="Gelf" name="graylog" endpoint="tcp://192.168.99.100:12201" ignoreTlsErrors="false" useTls="true" facility="console-runner" sendLastFormatParameter="true" gelfVersion="1.1" clientCertificate="base64:{pfx base64}" />
   </targets>
   <rules>
     <logger name="*" minlevel="Debug" writeTo="debugFile, graylog" />

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfTarget.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/GelfTarget.cs
@@ -4,9 +4,12 @@ using NLog.Targets;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
 
 namespace NLog.Web.AspNetCore.Targets.Gelf
 {
@@ -38,11 +41,21 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
 
         public string GelfVersion { get; set; } = "1.0";
 
+        public string ClientCertificate { get; set; }
+
+        public string ClientCertificatePassword { get; set; }
+
+        public bool IgnoreTlsErrors { get; set; }
+
+        public bool UseTls { get; set; }
+
         public IConverter Converter { get; private set; }
         public IEnumerable<ITransport> Transports { get; private set; }
         public DnsBase Dns { get; private set; }
 
-        public GelfTarget() : this(new[] { new UdpTransport(new UdpTransportClient()) }, new GelfConverter(), new DnsWrapper())
+        public X509Certificate2 X509Certificate { get; private set; }
+
+        public GelfTarget() : this(new ITransport[] { new UdpTransport(new UdpTransportClient()), new TcpTransport(new TcpTransportClient()) }, new GelfConverter(), new DnsWrapper())
         {
         }
 
@@ -61,8 +74,45 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
             });
             _lazyITransport = new Lazy<ITransport>(() =>
             {
-                return Transports.Single(x => x.Scheme.ToUpper() == _endpoint.Scheme.ToUpper());
+                var transport = Transports.Single(x => x.Scheme.ToUpper() == _endpoint.Scheme.ToUpper());
+                transport.Target = this;
+                if(transport.Scheme.Equals("tcp", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    if(!String.IsNullOrEmpty(ClientCertificate))
+                        LoadClientCertificate();
+                }
+
+                return transport;
             });
+        }
+
+        /// <summary>
+        /// Load Client Certificate for mTLS TCP connection
+        /// </summary>
+        /// <exception cref="ArgumentException">Somthing wrong with ClientCertificate parameter</exception>
+        /// <exception cref="Exception"></exception>
+        /// <exception cref="System.Security.Cryptography.CryptographicException"></exception>
+        public void LoadClientCertificate()
+        {
+            X509Certificate2 clientCertificate = null;
+            if (ClientCertificate?.StartsWith("file:") ?? false)
+            {
+                clientCertificate = new X509Certificate2(ClientCertificate.Replace("file:", string.Empty).Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar), ClientCertificatePassword);
+            }
+            else if (ClientCertificate?.StartsWith("base64:") ?? false)
+            {
+                var cert = new X509Certificate2();
+                cert.Import(Encoding.UTF8.GetBytes(ClientCertificate.Replace("base64", string.Empty)), ClientCertificatePassword, X509KeyStorageFlags.Exportable);
+                clientCertificate = cert;
+            }
+            else
+            {
+                throw new ArgumentException("Invalid Client Certificate path", nameof(this.ClientCertificate));
+            }
+            if (clientCertificate == null)
+                throw new Exception("Failed to load certificate");
+
+            X509Certificate = clientCertificate;
         }
 
         public void WriteLogEventInfo(LogEventInfo logEvent)

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/ITransport.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/ITransport.cs
@@ -4,6 +4,7 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
 {
     public interface ITransport
     {
+        GelfTarget Target { get; set; }
         string Scheme { get; }
         void Send(IPEndPoint target, string message);
     }

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/ITransportClient.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/ITransportClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 
@@ -6,6 +7,5 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
     public interface ITransportClient
     {
         void Send(byte[] datagram, int bytes, IPEndPoint ipEndPoint);
-        void Send(byte[] datagram, int bytes, IPEndPoint ipEndPoint, bool useTls, X509Certificate2 clientCertificate = null);
     }
 }

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/ITransportClient.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/ITransportClient.cs
@@ -1,9 +1,11 @@
 using System.Net;
+using System.Security.Cryptography.X509Certificates;
 
 namespace NLog.Web.AspNetCore.Targets.Gelf
 {
     public interface ITransportClient
     {
         void Send(byte[] datagram, int bytes, IPEndPoint ipEndPoint);
+        void Send(byte[] datagram, int bytes, IPEndPoint ipEndPoint, bool useTls, X509Certificate2 clientCertificate = null);
     }
 }

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/TcpTransport.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/TcpTransport.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace NLog.Web.AspNetCore.Targets.Gelf
+{
+    public class TcpTransport : ITransport
+    {
+        public GelfTarget Target { get; set; }
+
+        private readonly ITransportClient _transportClient;
+        public TcpTransport(ITransportClient transportClient)
+        {
+            _transportClient = transportClient;
+        }
+
+        /// <summary>
+        /// Sends a UDP datagram to GrayLog2 server
+        /// </summary>
+        /// <param name="serverIpAddress">IP address of the target GrayLog2 server</param>
+        /// <param name="serverPort">Port number of the target GrayLog2 instance</param>
+        /// <param name="message">Message (in JSON) to log</param>
+        public void Send(string serverIpAddress, int serverPort, string message)
+        {
+            var ipAddress = IPAddress.Parse(serverIpAddress);
+            var ipEndPoint = new IPEndPoint(ipAddress, serverPort);
+
+            Send(ipEndPoint, message);
+        }
+
+        /// <summary>
+        /// Sends a UDP datagram to GrayLog2 server
+        /// </summary>
+        /// <param name="target">IP Endpoint of the  of the target GrayLog2 server</param>
+        /// <param name="message">Message (in JSON) to log</param>
+        public void Send(IPEndPoint target, string message)
+        {
+            var ipEndPoint = target;
+            byte[] messageBytes = Encoding.UTF8.GetBytes(message);
+
+            _transportClient.Send(messageBytes, messageBytes.Length, ipEndPoint, Target.UseTls);
+        }
+
+        /// <summary>
+        /// Inserts bits from the given byte into the given BitArray instance.
+        /// </summary>
+        /// <param name="bitArray">BitArray instance to be populated with bits</param>
+        /// <param name="bitArrayIndex">Index pointer in BitArray to start inserting bits from</param>
+        /// <param name="byteData">Byte to extract bits from and insert into the given BitArray instance</param>
+        /// <param name="byteDataIndex">Index pointer in byteData to start extracting bits from</param>
+        /// <param name="length">Number of bits to extract from byteData</param>
+        private static void AddToBitArray(BitArray bitArray, int bitArrayIndex, byte byteData, int byteDataIndex, int length)
+        {
+            var localBitArray = new BitArray(new[] { byteData });
+
+            for (var i = byteDataIndex + length - 1; i >= byteDataIndex; i--)
+            {
+                bitArray.Set(bitArrayIndex, localBitArray.Get(i));
+                bitArrayIndex++;
+            }
+        }
+
+        public string Scheme
+        {
+            get { return "tcp"; }
+        }
+    }
+}

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/TcpTransport.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/TcpTransport.cs
@@ -14,10 +14,15 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
     {
         public GelfTarget Target { get; set; }
 
-        private readonly ITransportClient _transportClient;
+        private ITransportClient _transportClient;
         public TcpTransport(ITransportClient transportClient)
         {
             _transportClient = transportClient;
+        }
+
+        public void SetTransportClient(ITransportClient client)
+        {
+            _transportClient = client;
         }
 
         /// <summary>
@@ -44,7 +49,7 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
             var ipEndPoint = target;
             byte[] messageBytes = Encoding.UTF8.GetBytes(message);
 
-            _transportClient.Send(messageBytes, messageBytes.Length, ipEndPoint, Target.UseTls);
+            _transportClient.Send(messageBytes, messageBytes.Length, ipEndPoint);
         }
 
         /// <summary>

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/TcpTransportClient.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/TcpTransportClient.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+
+namespace NLog.Web.AspNetCore.Targets.Gelf
+{
+    public class TcpTransportClient : ITransportClient
+    {
+        public void Send(byte[] datagram, int bytes, IPEndPoint ipEndPoint)
+        {
+            using (var tcpClient = new TcpClient())
+            {
+                tcpClient.Connect(ipEndPoint);
+                int result = tcpClient.Client.Send(datagram, bytes, SocketFlags.None);
+            }
+        }
+
+        public void Send(byte[] datagram, int bytes, IPEndPoint ipEndPoint, bool useTls, X509Certificate2 clientCertificate = null)
+        {
+            if (!useTls)
+            {
+                Send(datagram, bytes, ipEndPoint);
+                return;
+            }
+
+            using (var tcpClient = new TcpClient())
+            {
+                tcpClient.Connect(ipEndPoint);
+                using (SslStream sslStream = new SslStream(tcpClient.GetStream(), false, new RemoteCertificateValidationCallback(ValidateServerCertificate), null))
+                {
+                    if (clientCertificate != null) sslStream.AuthenticateAsClient(ipEndPoint.Address.ToString(), new X509CertificateCollection(new[] { clientCertificate }), true);
+                    else sslStream.AuthenticateAsClient(ipEndPoint.Address.ToString());
+                    sslStream.Write(datagram);
+                }
+            }
+        }
+
+        private bool ValidateServerCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        {
+            return (sslPolicyErrors == SslPolicyErrors.None) ? true : false;
+        }
+    }
+}

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/TcpTransportClient.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/TcpTransportClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -8,38 +9,74 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
 {
     public class TcpTransportClient : ITransportClient
     {
+        private readonly bool _useTls;
+        private readonly bool _ignoreCertErrors;
+        private readonly X509Certificate2Collection _certsChain;
+
+        public TcpTransportClient() { }
+
+        /// <summary>
+        /// Create TCP client with parametes
+        /// </summary>
+        /// <param name="useTls">Use secure SSL/TLS channel</param>
+        /// <param name="ignoreCertificatesErrors">Ignore certificates errors</param>
+        /// <param name="clientCetificateChain">(Optional) Client Certificate</param>
+        public TcpTransportClient(bool useTls, bool ignoreCertificatesErrors, X509Certificate2Collection clientCetificateChain)
+        {
+            _useTls = useTls;
+            _ignoreCertErrors = ignoreCertificatesErrors;
+            _certsChain = clientCetificateChain;
+        }
+
         public void Send(byte[] datagram, int bytes, IPEndPoint ipEndPoint)
         {
             using (var tcpClient = new TcpClient())
             {
                 tcpClient.Connect(ipEndPoint);
-                int result = tcpClient.Client.Send(datagram, bytes, SocketFlags.None);
-            }
-        }
-
-        public void Send(byte[] datagram, int bytes, IPEndPoint ipEndPoint, bool useTls, X509Certificate2 clientCertificate = null)
-        {
-            if (!useTls)
-            {
-                Send(datagram, bytes, ipEndPoint);
-                return;
-            }
-
-            using (var tcpClient = new TcpClient())
-            {
-                tcpClient.Connect(ipEndPoint);
-                using (SslStream sslStream = new SslStream(tcpClient.GetStream(), false, new RemoteCertificateValidationCallback(ValidateServerCertificate), null))
+                if (_useTls)
                 {
-                    if (clientCertificate != null) sslStream.AuthenticateAsClient(ipEndPoint.Address.ToString(), new X509CertificateCollection(new[] { clientCertificate }), true);
-                    else sslStream.AuthenticateAsClient(ipEndPoint.Address.ToString());
-                    sslStream.Write(datagram);
+                    using (SslStream sslStream = new SslStream(tcpClient.GetStream(), false, new RemoteCertificateValidationCallback(ValidateServerCertificate), new LocalCertificateSelectionCallback(ValidateLocalCertificate), EncryptionPolicy.RequireEncryption))
+                    {
+                        if (_certsChain?.Count > 0) sslStream.AuthenticateAsClient(ipEndPoint.Address.ToString(), _certsChain, ((_ignoreCertErrors) ? false : true));
+                        else sslStream.AuthenticateAsClient(ipEndPoint.Address.ToString());
+                        sslStream.Write(datagram);
+                    }
+                }
+                else
+                {
+                    tcpClient.Client.Send(datagram, bytes, SocketFlags.None);
                 }
             }
         }
 
+        private X509Certificate ValidateLocalCertificate(object sender, string targetHost, X509CertificateCollection localCertificates, X509Certificate remoteCertificate, string[] acceptableIssuers)
+        {
+            if (localCertificates?.Count < 1) return null;
+
+            // If acceptableIssuers (client certificate subject) is not empty, get only acceptable certificates if not then all certificates all acceptable.
+            X509CertificateCollection acceptableCertificates = new X509CertificateCollection();
+            if (acceptableIssuers?.Length > 0)
+            {
+                foreach (var cert in localCertificates)
+                {
+                    if (acceptableIssuers.Contains(cert.Subject))
+                        acceptableCertificates.Add(cert);
+                }
+            }
+            else
+            {
+                acceptableCertificates = localCertificates;
+            }
+
+            // In case theres a chain certificate, intermediate certificates are first. Last certificate is Client Certificate.
+            return acceptableCertificates[acceptableCertificates.Count - 1];
+        }
+
         private bool ValidateServerCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
-            return (sslPolicyErrors == SslPolicyErrors.None) ? true : false;
+            return (sslPolicyErrors == SslPolicyErrors.None)
+                ? true
+                : ((_ignoreCertErrors) ? true : false);
         }
     }
 }

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/UdpTransport.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/UdpTransport.cs
@@ -12,6 +12,8 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
 {
     public class UdpTransport : ITransport
     {
+        public GelfTarget Target { get; set; }
+
         //UDP datagrams are limited to a size of 8192 bytes.
         private const int MaxMessageSizeInUdp = 8192;
         //Chunk also contains 12 byte prefix, so 8192 - 12.
@@ -191,6 +193,11 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
                 bitArray.Set(bitArrayIndex, localBitArray.Get(i));
                 bitArrayIndex++;
             }
+        }
+
+        void ITransport.Send(IPEndPoint target, string message)
+        {
+            throw new NotImplementedException();
         }
 
         public string Scheme

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/UdpTransport.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/UdpTransport.cs
@@ -195,11 +195,6 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
             }
         }
 
-        void ITransport.Send(IPEndPoint target, string message)
-        {
-            throw new NotImplementedException();
-        }
-
         public string Scheme
         {
             get { return "udp"; }

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/UdpTransportClient.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/UdpTransportClient.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 
 namespace NLog.Web.AspNetCore.Targets.Gelf
 {
@@ -11,6 +12,11 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
             {
                 int result = udpClient.Send(datagram, bytes, ipEndPoint);
             }
+        }
+
+        public void Send(byte[] datagram, int bytes, IPEndPoint ipEndPoint, bool useTls, X509Certificate2 clientCertificate = null)
+        {
+            throw new System.NotImplementedException("UDP Protocol dose not support TLS.");
         }
     }
 }

--- a/NLog.Web.AspNetCore.Targets.Gelf/Target/UdpTransportClient.cs
+++ b/NLog.Web.AspNetCore.Targets.Gelf/Target/UdpTransportClient.cs
@@ -13,10 +13,5 @@ namespace NLog.Web.AspNetCore.Targets.Gelf
                 int result = udpClient.Send(datagram, bytes, ipEndPoint);
             }
         }
-
-        public void Send(byte[] datagram, int bytes, IPEndPoint ipEndPoint, bool useTls, X509Certificate2 clientCertificate = null)
-        {
-            throw new System.NotImplementedException("UDP Protocol dose not support TLS.");
-        }
     }
 }


### PR DESCRIPTION
Hi, i have created TCP implementation with optional channel encryption and client certificate authentication.

Tested on Graylog 4.2.5 with self-signed certificates.

**Added TCP protocol**

Protocol selection is same as for UDP, simply use tcp:// or udp:// at begins of parameter `endpoint`.

**Added options to target**

- `ignoreTlsErrors` [bool] - Ignore invalid server certificate and don't checking revocation of client certificate
- `useTls` [bool] - Simply creating SslStream for TCP transmission.
- `clientCertificate` [string] - Theres two option for providing client certificate, base64 string or file path prefix. Client Certificate need to be in PKCS12 format and contains private key (can be password protected)
- `clientCertificatePassword` [string] - Password for Client Certificate, it is optional if certificate private key is not password protected.

**NLog.config targets examples***

Use TCP with file certificate
```
<target xsi:type="Gelf" name="graylog" endpoint="tcp://192.168.99.100:12201" ignoreTlsErrors="false" useTls="true" facility="console-runner" sendLastFormatParameter="true" gelfVersion="1.1" clientCertificate="file:cert.pfx" />
```